### PR TITLE
Changed isDCOPublication to isContributionToDCO

### DIFF
--- a/js/widgets/DCOPubBooleanSelect.js
+++ b/js/widgets/DCOPubBooleanSelect.js
@@ -15,7 +15,7 @@ edu.rpi.tw.sesf.s2s.widgets.DCOPubBooleanSelect = function(panel)
 {
     this.panel = panel;
     var input = panel.getInput();
-    var select = jQuery("<input id=\"member_check\" type=\"checkbox\" value=\"members\" checked=\"checked\">List DCO Publications Only</input>");
+    var select = jQuery("<input id=\"member_check\" type=\"checkbox\" value=\"members\" checked=\"checked\">Only show contributions to the DCO</input>");
     this.div = jQuery("<div class=\"facet-content\" style=\"width:100%\"></div>");
     panel.setInputData(input.getId(), function() {
 	var arr = [];

--- a/opensearch/services/publications/publications.php
+++ b/opensearch/services/publications/publications.php
@@ -352,7 +352,7 @@ class DCO_Publications_S2SConfig extends S2SConfig {
 			case "dcoPubs":
 				if( $constraint_value == "yes" )
 				{
-				    $body .= "?publication dco:isDCOPublication ?isit ." ;
+				    $body .= "?publication dco:isContributionToDCO ?isit ." ;
 				    $body .= "FILTER (lcase(str(?isit)) = \"yes\") ." ;
 				}
 				break;


### PR DESCRIPTION
Per the request from the Secretariat we've changed the property from
isDCOPublication to isContributionToDCO and the wording of the checkbox
to match.
